### PR TITLE
Feat/action save cue

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -35,6 +35,29 @@ module.exports = {
 			}
 		}
 
+    actions.saveCue = {
+      name: 'Save Cue',
+      options: [
+        {
+          type: 'number',
+          label: 'Cue Number',
+          id: 'cueNumber',
+          min: 1,
+          max: 99,
+          default: 1,
+          required: true,
+          range: false
+        }
+      ],
+      callback: async function(event) {
+        let cmd = {
+          CueNum: event.options.cueNumber,
+          EndFlag: 1
+        }
+        self.sendSaveCueCommand(cmd);
+      }
+    }
+
 		actions.clearCue = {
 			name: 'Clear Cue',
 			options: [],

--- a/src/api.js
+++ b/src/api.js
@@ -68,6 +68,23 @@ module.exports = {
 			this.log('error', 'Error Sending Run Cue Command ' + error.toString());
 		}.bind(this));
 	},
+
+  sendRunCueCommand(cmd) {
+		this.log('info', 'Saving Cue ' + cmd.CueNum);
+
+		let args = {
+			data: cmd,
+			headers: { "Content-Type": "application/x-www-form-urlencoded" }
+		};
+	
+		let client = new Client();
+	
+		client.post('http://' + this.config.host + '/save_cues', args, function (data, response) {
+			//do something with response
+		}.bind(this)).on('error', function(error) {
+			this.log('error', 'Error Sending Save Cue Command ' + error.toString());
+		}.bind(this));
+	},
 	
 	sendClearCueCommand() {
 		let cmd = {

--- a/src/api.js
+++ b/src/api.js
@@ -69,7 +69,7 @@ module.exports = {
 		}.bind(this));
 	},
 
-  sendRunCueCommand(cmd) {
+  sendSaveCueCommand(cmd) {
 		this.log('info', 'Saving Cue ' + cmd.CueNum);
 
 		let args = {


### PR DESCRIPTION
This pull request adds support for saving cues in the application. The main changes include introducing a new `Save Cue` action and implementing the corresponding API call to handle cue saving.

**New Save Cue functionality:**

* Added a `saveCue` action to `src/actions.js`, allowing users to save a cue by specifying its number.
<img width="660" height="147" alt="image" src="https://github.com/user-attachments/assets/5c144798-7ca5-4ce6-80dc-8e79bf7c5a6d" />

**API integration:**

* Implemented the `sendSaveCueCommand` method in `src/api.js` to send a POST request to the `/save_cues` endpoint, enabling the backend to process cue saving. 