### PR TITLE
Fix TypeError: self.status is not a function in getCurrentCue error handler

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -43,7 +43,7 @@ module.exports = {
 				self.updateStatus(InstanceStatus.Ok);
 			}
 		}.bind(self)).on('error', function(error) {
-			self.status(InstanceStatus.Error);
+			self.updateStatus(InstanceStatus.Error);
 			self.log('error', 'Error Getting Current Cue: ' + error.toString());
 			if  (self.INTERVAL !== undefined) {
 				self.log('debug', 'Stopping Polling...');


### PR DESCRIPTION
Summary

Replaces a leftover call to the Companion 2.x status() method with the current updateStatus() method in the getCurrentCue polling error handler.

Problem

When the polling request to CuesStatus.json fails (e.g. the device is unreachable), the .on('error', …) handler in getCurrentCue runs self.status(InstanceStatus.Error). That method does not exist on @companion-module/base — it was renamed to updateStatus() during the Companion 2.x → 3.x migration. Instead of surfacing an error status, the module throws and crashes the process:

TypeError: self.status is not a function
    at NetronENInstance.<anonymous> (src/api.js:46:9)
    ...
Node.js v18.20.8